### PR TITLE
chore: completely skip response verification for "raw"

### DIFF
--- a/packages/ic-http-gateway/src/consts.rs
+++ b/packages/ic-http-gateway/src/consts.rs
@@ -1,4 +1,3 @@
-pub(crate) static IC_CERTIFICATE_HEADER_NAME: &str = "ic-certificate";
 pub(crate) static CACHE_HEADER_NAME: &str = "cache-control";
 pub(crate) static ACCEPT_ENCODING_HEADER_NAME: &str = "accept-encoding";
 

--- a/packages/ic-http-gateway/src/protocol/handler.rs
+++ b/packages/ic-http-gateway/src/protocol/handler.rs
@@ -62,7 +62,7 @@ pub async fn process_request(
     agent: &Agent,
     request: CanisterRequest,
     canister_id: Principal,
-    allow_skip_verification: bool,
+    skip_verification: bool,
 ) -> HttpGatewayResponse {
     let http_request = match convert_request(request) {
         Ok(http_request) => http_request,
@@ -197,7 +197,7 @@ pub async fn process_request(
                         body,
                         upgrade: None,
                     },
-                    allow_skip_verification,
+                    skip_verification,
                 );
 
                 match validation_result {

--- a/packages/ic-http-gateway/src/protocol/validate.rs
+++ b/packages/ic-http-gateway/src/protocol/validate.rs
@@ -1,4 +1,4 @@
-use crate::{HttpGatewayResult, IC_CERTIFICATE_HEADER_NAME};
+use crate::HttpGatewayResult;
 use candid::Principal;
 use ic_agent::Agent;
 use ic_http_certification::{HttpRequest, HttpResponse};
@@ -16,35 +16,24 @@ pub fn validate(
     response: HttpResponse,
     allow_skip_verification: bool,
 ) -> HttpGatewayResult<Option<VerificationInfo>> {
-    match (allow_skip_verification, has_ic_certificate(&response)) {
+    if allow_skip_verification {
         // TODO: Remove this (FOLLOW-483)
         // Canisters don't have to provide certified variables
         // This should change in the future, grandfathering in current implementations
-        (true, false) => Ok(None),
-        (_, _) => {
-            let ic_public_key = agent.read_root_key();
-            let verification_info = verify_request_response_pair(
-                request,
-                response,
-                canister_id.as_slice(),
-                get_current_time_in_ns(),
-                MAX_CERT_TIME_OFFSET_NS,
-                ic_public_key.as_slice(),
-                MIN_VERIFICATION_VERSION,
-            )?;
-            Ok(Some(verification_info))
-        }
-    }
-}
-
-fn has_ic_certificate(response: &HttpResponse) -> bool {
-    for (header_name, _) in &response.headers {
-        if header_name.eq_ignore_ascii_case(IC_CERTIFICATE_HEADER_NAME) {
-            return true;
-        }
+        return Ok(None);
     }
 
-    false
+    let ic_public_key = agent.read_root_key();
+    let verification_info = verify_request_response_pair(
+        request,
+        response,
+        canister_id.as_slice(),
+        get_current_time_in_ns(),
+        MAX_CERT_TIME_OFFSET_NS,
+        ic_public_key.as_slice(),
+        MIN_VERIFICATION_VERSION,
+    )?;
+    Ok(Some(verification_info))
 }
 
 fn get_current_time_in_ns() -> u128 {

--- a/packages/ic-http-gateway/src/protocol/validate.rs
+++ b/packages/ic-http-gateway/src/protocol/validate.rs
@@ -14,9 +14,9 @@ pub fn validate(
     canister_id: &Principal,
     request: HttpRequest,
     response: HttpResponse,
-    allow_skip_verification: bool,
+    skip_verification: bool,
 ) -> HttpGatewayResult<Option<VerificationInfo>> {
-    if allow_skip_verification {
+    if skip_verification {
         // TODO: Remove this (FOLLOW-483)
         // Canisters don't have to provide certified variables
         // This should change in the future, grandfathering in current implementations

--- a/packages/ic-http-gateway/src/request/http_gateway_request_builder.rs
+++ b/packages/ic-http-gateway/src/request/http_gateway_request_builder.rs
@@ -20,22 +20,22 @@ pub struct HttpGatewayRequestBuilderArgs<'a> {
 
 pub struct HttpGatewayRequestBuilder<'a> {
     args: HttpGatewayRequestBuilderArgs<'a>,
-    allow_skip_verification: bool,
+    skip_verification: bool,
 }
 
 impl<'a> HttpGatewayRequestBuilder<'a> {
     pub fn new(args: HttpGatewayRequestBuilderArgs<'a>) -> Self {
         Self {
             args,
-            allow_skip_verification: false,
+            skip_verification: false,
         }
     }
 
     pub fn unsafe_set_allow_skip_verification(
         &mut self,
-        allow_skip_verification: bool,
+        skip_verification: bool,
     ) -> &mut Self {
-        self.allow_skip_verification = allow_skip_verification;
+        self.skip_verification = skip_verification;
 
         self
     }
@@ -45,7 +45,7 @@ impl<'a> HttpGatewayRequestBuilder<'a> {
             self.args.agent,
             self.args.request_args.canister_request,
             self.args.request_args.canister_id,
-            self.allow_skip_verification,
+            self.skip_verification,
         )
         .await
     }

--- a/packages/ic-http-gateway/src/request/http_gateway_request_builder.rs
+++ b/packages/ic-http-gateway/src/request/http_gateway_request_builder.rs
@@ -31,10 +31,7 @@ impl<'a> HttpGatewayRequestBuilder<'a> {
         }
     }
 
-    pub fn unsafe_set_allow_skip_verification(
-        &mut self,
-        skip_verification: bool,
-    ) -> &mut Self {
+    pub fn unsafe_set_allow_skip_verification(&mut self, skip_verification: bool) -> &mut Self {
         self.skip_verification = skip_verification;
 
         self


### PR DESCRIPTION
Instead of only skipping verification if no certificate is present, now the library always skips response verification regardless of a certificate if instructed to do so.