### PR TITLE
fix: remove dependency on regex to reduce WASM size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,10 +1120,10 @@ dependencies = [
  "include_dir",
  "lazy_static",
  "rand_chacha",
- "regex",
  "serde",
  "serde_cbor",
  "sha2 0.10.8",
+ "text_io",
 ]
 
 [[package]]
@@ -1448,11 +1448,11 @@ dependencies = [
  "ic-utils",
  "pocket-ic",
  "rand_chacha",
- "regex",
  "reqwest",
  "rstest",
  "sha2 0.10.8",
  "testcontainers",
+ "text_io",
  "thiserror",
  "tokio",
 ]
@@ -3005,6 +3005,12 @@ dependencies = [
  "tokio-util",
  "url",
 ]
+
+[[package]]
+name = "text_io"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f0c8eb2ad70c12a6a69508f499b3051c924f4b1cfeae85bfad96e6bc5bba46"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ bytes = "1"
 base64 = "0.22"
 lazy_static = "1"
 rand_chacha = "0.3"
-regex = "1"
 serde = "1"
 serde_cbor = "0.11"
 sha2 = "0.10"
+text_io = "0.1"
 tokio = { version = "1", features = ["full"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = "0.1"

--- a/examples/http-gateway/canister/src/custom_assets/Cargo.toml
+++ b/examples/http-gateway/canister/src/custom_assets/Cargo.toml
@@ -11,10 +11,10 @@ candid.workspace = true
 http.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true
-regex.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
 sha2.workspace = true
+text_io.workspace = true
 lazy_static.workspace = true
 base64.workspace = true
 include_dir = { version = "0.7", features = ["glob"] }

--- a/packages/ic-http-gateway/Cargo.toml
+++ b/packages/ic-http-gateway/Cargo.toml
@@ -26,7 +26,7 @@ http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 bytes.workspace = true
-regex.workspace = true
+text_io.workspace = true
 
 ic-agent.workspace = true
 ic-utils.workspace = true


### PR DESCRIPTION
Using `regex`-crate increases the WASM-size of canisters by over 100 kB. This PR replaces `regex` with `text_io`, which is much smaller yet sufficient for the parsing that `regex` was used.  For example the canister `http_gateway_canister_custom_assets` with `regex` had size 466'631 bytes, while with `text_io` only 349'393 bytes.

TT-440